### PR TITLE
Replace gfm with commonmark

### DIFF
--- a/lettersmith/markdowntools.py
+++ b/lettersmith/markdowntools.py
@@ -1,16 +1,9 @@
-from markdown import markdown as md
-from mdx_gfm import GithubFlavoredMarkdownExtension
+from commonmark import commonmark
 from lettersmith.html import strip_html
 from lettersmith import docs as Docs
 from lettersmith.func import compose
 
 
-def markdown(s):
-    """
-    Render markdown on content field.
-    """
-    return md(s, extensions=(GithubFlavoredMarkdownExtension(),))
-
-
+markdown = commonmark
 strip_markdown = compose(strip_html, markdown)
 content = Docs.renderer(markdown)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(exclude=("tests", "tests.*")),
     install_requires=[
         "PyYAML>=3.13",
-        "py-gfm>=0.1.3",
+        "commonmark>=0.9.1",
         "python-frontmatter>=0.3.1",
         "Jinja2>=2.7"
         # TODO


### PR DESCRIPTION
Fixes https://github.com/gordonbrander/lettersmith_py/issues/8.

GFM doesn't ignore inline HTML when rendering, and will produce bugs,
such as re-hrefing the href in a link tag.

GFM has essentially been abandoned. This PR replaces it with commonmark,
which implements Common Markdown (https://commonmark.org/).

Pros:

- Commonmark is maintained by readthedocs, so is a good bet in terms of
code durability.
- Edge-cases in CommonMark are well-specified.
- The library generates an AST, which we could use for enhancements
  later.

Cons:

- No auto-linking of bare URLs. You need to wrap URLs in <brackets>
- No br for soft linebreaks. you will need to add two spaces at the end
  of the line to create a BR.